### PR TITLE
Fixed issue #4

### DIFF
--- a/ftplugin/haskell/hdevtools.vim
+++ b/ftplugin/haskell/hdevtools.vim
@@ -34,3 +34,24 @@ let b:undo_ftplugin .= join(map([
       \ 'HdevtoolsInfo'
       \ ], '"delcommand " . v:val'), ' | ')
 let b:undo_ftplugin .= ' | unlet b:did_ftplugin_hdevtools'
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+"
+" Functions
+" 
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+fun! DeleteSocketFile()
+    if fileisreadable(".hdevtools.sock")
+        system("rm .hdevtools.sock")
+    endif
+endfun
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+"
+" Autocommands
+"
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+au VimEnter :call DeleteSocketFile()
+au VimLeave :call DeleteSocketFile()


### PR DESCRIPTION
I've added two simple autocommands which ensures the socket file is properly deleted.

Deleting the socket file is important for me for 2 reasons:

1) Avoid polluting every single folder with a socket file
2) Avoid that a mal-closed socket hangs hdevtools

Cheers,
A.
