### PR TITLE
Ignore compiler warnings in output of `hdevtools type`

### DIFF
--- a/autoload/hdevtools.vim
+++ b/autoload/hdevtools.vim
@@ -475,7 +475,9 @@ function! hdevtools#type()
   let l:types = []
   for l:line in split(l:output, '\n')
     let l:m = matchlist(l:line, '\(\d\+\) \(\d\+\) \(\d\+\) \(\d\+\) "\([^"]\+\)"')
-    call add(l:types, [l:m[1 : 4], l:m[5]])
+    if len(l:m) != 0
+      call add(l:types, [l:m[1 : 4], l:m[5]])
+    endif
   endfor
 
   call hdevtools#clear_highlight()


### PR DESCRIPTION
First, thanks for this amazing Haskell tool! hdevtools is very handy and fast as hell.

This just fixes a minor bug when a warning appears as part of hdevtool's output. I'm not 100% sure if the VIM plugin is the correct place to fix this, because I don't know if mixing the warnings with the output makes sense at all, but it works for me as a workaround for now.
