### PR TITLE
Haskell Tool Stack awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ appropriate (such as your project's `Session.vim`):
 Make sure that each GHC option has its own `-g` prefix (don't group multiple
 options like this: `"-g-isrc\ -Wall"`)
 
+I recommend setting the flag to
+[defer GHC type errors to runtime](<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deferring-type-errors-to-runtime>),
+so that Haskell expressions can be typechecked even if type errors
+elsewhere in the project would otherwise prevent GHC from compiling.
+
+    let g:hdevtools_options = '-g-fdefer-type-errors'
 
 Credits
 -------

--- a/README.md
+++ b/README.md
@@ -19,21 +19,55 @@ editor.
 This is the Vim plugin that integrates Vim with hdevtools.
 
 
+Requirements
+------------
+
+The *vim-hdevtools* plugin requires a way to run `hdevtools`. Here are the
+ways to make `hdevtools` available to the plugin.
+
+### Global `hdevtools`
+
+Install the `hdevtools` command line program so that it is on your
+executable `$PATH`.
+
+Get it from Github: <https://github.com/hdevtools/hdevtools/>
+
+Or from Hackage:
+
+    $ cabal install hdevtools
+
+Or from Stackage:
+
+    $ stack install hdevtools
+
+Note that `hdevtools` must be built with the same version of GHC as the
+project which you will be editing.
+
+### Local `hdevtools` with `stack`
+
+If your project is built with [stack](<https://www.haskellstack.org>) and
+if you run Vim from the directory that contains `stack.yaml`, then
+the *vim-hdevtools* plugin can employ `stack` to automatically install
+`hdevtools` built with the same version of GHC indicated by the resolver
+in your `stack.yaml`. This will not conflict with any other installations
+of `hdevtools` on your system.
+
+If you want the *vim-hdevtools* plugin to use `stack`,
+you have to enable this feature in your `.vimrc` like so:
+
+    let g:hdevtools_stack = 1
+
+
 Installation
 ------------
 
-1. You must install the `hdevtools` command line program, It can be found
-   here: <https://github.com/hdevtools/hdevtools/>, or from Hackage:
-
-        $ cabal install hdevtools
-
-2. Install this plugin. [pathogen.vim](<https://github.com/tpope/vim-pathogen/>)
+1. Install this plugin. [pathogen.vim](<https://github.com/tpope/vim-pathogen/>)
    is the recommended way:
 
         cd ~/.vim/bundle
         git clone https://github.com/bitc/vim-hdevtools.git
 
-3. Configure your keybindings in your `.vimrc` file. I recommend something
+2. Configure your keybindings in your `.vimrc` file. I recommend something
    like:
 
         au FileType haskell nnoremap <buffer> <F1> :HdevtoolsType<CR>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Installation
    like:
 
         au FileType haskell nnoremap <buffer> <F1> :HdevtoolsType<CR>
-        au FileType haskell nnoremap <buffer> <silent> <F2> :HdevtoolsClear<CR>
+        au FileType haskell nnoremap <buffer> <silent> <F2> :HdevtoolsInfo<CR>
+        au FileType haskell nnoremap <buffer> <silent> <F3> :HdevtoolsClear<CR>
 
 
 Features
@@ -60,6 +61,9 @@ Position the cursor anywhere in a Haskell source file, and execute
 The type for the expression under the cursor will be printed, and the
 expression will be highlighted. Repeated presses will expand the expression
 that is examined.
+
+To get information from GHC about the identifier under cursor,
+execute `HdevtoolsInfo` (or press the `<F2>` key as configured above).
 
 You can execute `HdevtoolsClear` to get rid of the highlighting.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ hdevtools Vim Plugin
 ====================
 
 Vim plugin for Haskell development powered by the lightning fast
-[hdevtools](<https://github.com/bitc/hdevtools/>) background server.
+[hdevtools](<https://github.com/hdevtools/hdevtools/>) background server.
 
 
 About
 -----
 
-[hdevtools](<https://github.com/bitc/hdevtools/>) is a command line program
+[hdevtools](<https://github.com/hdevtools/hdevtools/>) is a command line program
 powered by the GHC API, that provides services for Haskell development.
 hdevtools works by running a persistent process in the background, so that your
 Haskell modules remain in memory, instead of having to reload everything each
@@ -23,7 +23,7 @@ Installation
 ------------
 
 1. You must install the `hdevtools` command line program, It can be found
-   here: <https://github.com/bitc/hdevtools/>, or from Hackage:
+   here: <https://github.com/hdevtools/hdevtools/>, or from Hackage:
 
         $ cabal install hdevtools
 

--- a/autoload/hdevtools.vim
+++ b/autoload/hdevtools.vim
@@ -477,9 +477,7 @@ function! s:on_leave()
 endfunction
 
 function! hdevtools#build_command(command, args)
-  let l:cmd = 'hdevtools'
-  let l:cmd = l:cmd . ' ' . a:command . ' '
-
+  let l:cmd = g:hdevtools_exe . ' ' . a:command . ' '
   let l:cmd = l:cmd . get(g:, 'hdevtools_options', '') . ' '
   let l:cmd = l:cmd . a:args
   return l:cmd
@@ -487,8 +485,7 @@ endfunction
 
 " Does not include g:hdevtools_options
 function! hdevtools#build_command_bare(command, args)
-  let l:cmd = 'hdevtools'
-  let l:cmd = l:cmd . ' ' . a:command . ' '
+  let l:cmd = g:hdevtools_exe . ' ' . a:command . ' '
   let l:cmd = l:cmd . a:args
   return l:cmd
 endfunction

--- a/ftplugin/haskell/hdevtools.vim
+++ b/ftplugin/haskell/hdevtools.vim
@@ -6,7 +6,16 @@ let b:did_ftplugin_hdevtools = 1
 if !exists('s:has_hdevtools')
   let s:has_hdevtools = 0
 
-  if !executable('hdevtools')
+  " For stack support, vim must be started in the directory containing stack.yaml
+  if exists('g:hdevtools_stack') && g:hdevtools_stack && filereadable("stack.yaml")
+    if !executable('stack')
+      call hdevtools#print_error('hdevtools: stack.yaml found, but stack is not executable!')
+      finish
+    endif
+    let g:hdevtools_exe = 'stack exec --silent --no-ghc-package-path --package hdevtools hdevtools --'
+  elseif executable('hdevtools')
+    let g:hdevtools_exe = 'hdevtools'
+  else
     call hdevtools#print_error('hdevtools: hdevtools is not executable!')
     finish
   endif


### PR DESCRIPTION
Prevent *ghc* version mismatch between `hdevtools` and the project by using `stack` to invoke `hdevtools` instead of looking for `hdevtools` on the `$PATH`, to avoid issues such as https://github.com/hdevtools/hdevtools/issues/78

Because `hdevtools` generally needs to be built with the same *ghc* version as the project being examined by `hdevtools`, there is no way to "install" a global `hdevtools` which works for all Haskell projects on a machine. And there is no way to solve this problem by changing `hdevtools`. *stack* and *vim-hdevtools* together can provide a nice solution to the problem of having a specially-built `hdevtools` for each project.

__Possible problems or further work__

Add a configuration option to disable `stack.yaml` detection?