### PR TITLE
Implement "insert type definition of outer function under cursor".

### DIFF
--- a/ftplugin/haskell/hdevtools.vim
+++ b/ftplugin/haskell/hdevtools.vim
@@ -41,6 +41,7 @@ nnoremap <buffer> <silent> <C-W><C-F> :call hdevtools#go_file("sp")<CR>
 command! -buffer -nargs=0 HdevtoolsType echo hdevtools#type()[1]
 command! -buffer -nargs=0 HdevtoolsClear call hdevtools#type_clear()
 command! -buffer -nargs=? HdevtoolsInfo call hdevtools#info(<q-args>)
+command! -buffer -nargs=0 HdevtoolsInsertType call hdevtools#insert_type()
 
 let b:undo_ftplugin .= join(map([
       \ 'HdevtoolsType',


### PR DESCRIPTION
This adds a function hdevtools#insert_type() which inserts the type definition of the outer function under the cursor. The definition is inserted right above the definition of the function.

The functions first gets the number of the first line of the outer function via the last line of output of
`hdevtools type <file> <line of cursor> <column of cursor>`

This line number is then used to find the identifier of the function. The type is then determined via
`hdevtools info <file> <identifier>`